### PR TITLE
Next Display feature

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3445,6 +3445,7 @@ dependencies = [
  "core-foundation",
  "core-graphics",
  "dirs 5.0.1",
+ "global-hotkey",
  "objc",
  "objc2",
  "objc2-app-kit",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1"
 thiserror = "1"
 dirs = "5"
 tauri-plugin-process = "2.3.1"
+global-hotkey = "0.7.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.58", features = [

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -26,6 +26,7 @@ pub struct ShortcutConfig {
     pub right_two_thirds: String,
     pub center: String,
     pub maximize: String,
+    pub next_display: String,
 }
 
 impl Default for Config {
@@ -55,6 +56,7 @@ impl Default for ShortcutConfig {
             right_two_thirds: "Control+Alt+R".to_string(),
             center: "Control+Alt+C".to_string(),
             maximize: "Control+Alt+Enter".to_string(),
+            next_display: "Control+Alt+N".to_string(),
         }
     }
 }

--- a/src-tauri/src/hotkeys.rs
+++ b/src-tauri/src/hotkeys.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::window_manager::{SnapPosition, WindowManager};
+use global_hotkey::HotKeyState;
 use tauri::AppHandle;
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut};
 
@@ -23,15 +24,18 @@ pub fn register_hotkeys(app: &AppHandle) -> Result<(), Box<dyn std::error::Error
         (&shortcuts.right_two_thirds, SnapPosition::RightTwoThirds),
         (&shortcuts.center, SnapPosition::Center),
         (&shortcuts.maximize, SnapPosition::Maximize),
+        (&shortcuts.next_display, SnapPosition::NextDisplay),
     ];
 
     for (shortcut_str, position) in shortcut_mappings {
         let shortcut: Shortcut = shortcut_str.parse()?;
-        let pos = position.clone();
 
-        app.global_shortcut().on_shortcut(shortcut, move |_app, _shortcut, _event| {
+        app.global_shortcut().on_shortcut(shortcut, move |_app, _shortcut, event| {
+            if event.state == HotKeyState::Released {
+                return
+            }
             let manager = WindowManager::new();
-            if let Err(e) = manager.snap_to(pos.clone()) {
+            if let Err(e) = manager.snap_to(position) {
                 eprintln!("Failed to snap window: {}", e);
             }
         })?;

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -229,6 +229,13 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         accessibility_enabled,
         Some("ctrl+alt+c"),
     )?;
+    let next_dis = MenuItem::with_id(
+        app,
+        "next_display",
+        "Next Display",
+        accessibility_enabled,
+        Some("ctrl+alt+n"),
+    )?;
 
     // Separators
     let sep1 = PredefinedMenuItem::separator(app)?;
@@ -270,6 +277,7 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                 // Other
                 &maximize,
                 &center,
+                &next_dis,
                 &sep4,
                 // App controls
                 &settings,
@@ -301,6 +309,7 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                 // Other
                 &maximize,
                 &center,
+                &next_dis,
                 &sep4,
                 // App controls
                 &settings,
@@ -339,6 +348,7 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                 // Other (disabled)
                 &maximize,
                 &center,
+                &next_dis,
                 &sep4,
                 // App controls
                 &settings,
@@ -373,6 +383,7 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                 // Other (disabled)
                 &maximize,
                 &center,
+                &next_dis,
                 &sep4,
                 // App controls
                 &settings,
@@ -441,6 +452,7 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                 // Other
                 "maximize" => Some(SnapPosition::Maximize),
                 "center" => Some(SnapPosition::Center),
+                "next_display" => Some(SnapPosition::NextDisplay),
                 // Non-snap actions
                 "settings" => {
                     if let Some(window) = app.get_webview_window("main") {

--- a/src-tauri/src/window_manager/linux.rs
+++ b/src-tauri/src/window_manager/linux.rs
@@ -36,6 +36,12 @@ impl WindowManagerTrait for LinuxManager {
         // For Wayland, enumerate wl_output objects
         Err(WindowManagerError::PlatformNotSupported)
     }
+
+    fn get_next_display(&self) -> Result<Vec<Display>> {
+        // TODO: Implement using Xrandr for X11
+        // For Wayland, enumerate wl_output objects
+        Err(WindowManagerError::PlatformNotSupported)
+    }
 }
 
 impl Default for LinuxManager {

--- a/src-tauri/src/window_manager/macos.rs
+++ b/src-tauri/src/window_manager/macos.rs
@@ -558,6 +558,17 @@ impl WindowManagerTrait for MacOSManager {
             Ok(displays)
         }
     }
+    fn get_next_display(&self) -> Result<Vec<Display>> {
+        let cur_dis = self.get_current_display()?;
+        let mut all_dis = self.get_all_displays()?;
+        let mut next_id = 0;
+        for i in 0..all_dis.len() {
+            if all_dis[i].name == cur_dis.name && i < all_dis.len() {
+                next_id = i + 1;
+            }
+        }
+        Ok(all_dis.remove(next_id))
+    }
 }
 
 impl Default for MacOSManager {

--- a/src-tauri/src/window_manager/mod.rs
+++ b/src-tauri/src/window_manager/mod.rs
@@ -35,6 +35,9 @@ pub trait WindowManagerTrait: Send + Sync {
     /// Move and resize a window to the specified frame.
     fn set_window_frame(&self, window: &Window, frame: Rect) -> Result<()>;
 
+    /// Get the next display/monitor from the one containing the focused window.
+    fn get_next_display(&self) -> Result<Display>;
+
     /// Get the display/monitor containing the focused window.
     fn get_current_display(&self) -> Result<Display>;
 
@@ -71,7 +74,10 @@ impl WindowManager {
     /// Snap the focused window to the specified position.
     pub fn snap_to(&self, position: SnapPosition) -> Result<()> {
         let window = self.inner.get_focused_window()?;
-        let display = self.inner.get_current_display()?;
+        let display = match position {
+            SnapPosition::NextDisplay => self.inner.get_next_display()?,
+            _ => self.inner.get_current_display()?,
+        };
         let frame = position.calculate_frame(&display.work_area);
 
         self.inner.set_window_frame(&window, frame)

--- a/src-tauri/src/window_manager/types.rs
+++ b/src-tauri/src/window_manager/types.rs
@@ -69,6 +69,7 @@ pub enum SnapPosition {
     RightThird,
     LeftTwoThirds,
     RightTwoThirds,
+    NextDisplay,
 }
 
 impl SnapPosition {
@@ -104,6 +105,8 @@ impl SnapPosition {
             }
 
             SnapPosition::Maximize => Rect::new(x, y, w, h),
+
+            SnapPosition::NextDisplay => Rect::new(x, y, w, h),
 
             SnapPosition::LeftThird => Rect::new(x, y, w / 3, h),
             SnapPosition::CenterThird => Rect::new(x + (w / 3) as i32, y, w / 3, h),

--- a/src-tauri/src/window_manager/windows.rs
+++ b/src-tauri/src/window_manager/windows.rs
@@ -236,6 +236,18 @@ impl WindowManagerTrait for WindowsManager {
 
         Ok(displays)
     }
+
+    fn get_next_display(&self) -> Result<Display> {
+        let cur_dis = self.get_current_display()?;
+        let mut all_dis = self.get_all_displays()?;
+        let mut next_id = 0;
+        for i in 0..all_dis.len() {
+            if all_dis[i].name == cur_dis.name && i < all_dis.len() {
+                next_id = i + 1;
+            }
+        }
+        Ok(all_dis.remove(next_id))
+    }
 }
 
 impl Default for WindowsManager {


### PR DESCRIPTION
Not tested on macos
Not tested with real second monitor
Assuming some sane behavior:
- "Ctrl+Alt+N" hotkey
- Next monitor and maximize
- on_snap() only called 'on pressed' (I don't know why it wasn't and I could not find any problems)

closes #1